### PR TITLE
Readd Puddle Jumpers section link

### DIFF
--- a/about.html
+++ b/about.html
@@ -46,7 +46,7 @@
         <nav class="navbar navbar-expand-md navbar-dark sticky-top rainstorms-dark">
             <!-- our logos (which link to the home page and the puddle jumpers section of the about page, respectively) -->
             <a class="navbar-brand" href="/"><img src="images/logo.svg" height="50" alt="7190 Logo" loading="lazy"></a>
-            <a class="navbar-brand" href="about.html#pjoffset"><img src="images/logopj.svg" height="50" alt="7332 Logo" loading="lazy"></a>
+            <a class="navbar-brand" href="about.html#puddlejumpers"><img src="images/logopj.svg" height="50" alt="7332 Logo" loading="lazy"></a>
             <!-- the sandwich (menu) button that appears when the navbarContent collapses -->
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -119,7 +119,7 @@
                         </p>
                     </div>
                     <div class="col-12 my-4">
-                        <h2 class="rainstorms-title">The Puddle Jumpers</h2>
+                        <h2 class="rainstorms-title" id="puddlejumpers">The Puddle Jumpers</h2>
                         <p class="rainstorms-paragraph text-left">The Puddle Jumpers are the all-women robotics team within the Templeton Robotics Club.
                             We have created a new team with the goal of providing a safe and supportive space for girls and young women
                             to engage with robotics, technology, business and marketing. The Puddle Jumpers are the first all-women robotics team

--- a/contact.html
+++ b/contact.html
@@ -74,7 +74,7 @@
       <a class="navbar-brand" href="/"
         ><img src="images/logo.svg" height="50" alt="7190 Logo" loading="lazy"
       /></a>
-      <a class="navbar-brand" href="about.html#pjoffset"
+      <a class="navbar-brand" href="about.html#puddlejumpers"
         ><img
           src="images/logopj.svg"
           height="50"

--- a/css/main.css
+++ b/css/main.css
@@ -167,3 +167,7 @@ div#map embed {
 h7 {
   font-size: 50px;
 }
+
+#puddlejumpers {
+  scroll-margin-top: 200px;
+}

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
   <nav class="navbar navbar-expand-md navbar-dark sticky-top rainstorms-dark">
     <!-- our logos (which link to the home page and the puddle jumpers section of the about page, respectively) -->
     <a class="navbar-brand" href="/"><img src="images/logo.svg" height="50" alt="7190 Logo" loading="lazy" /></a>
-    <a class="navbar-brand" href="about.html#pjoffset"><img src="images/logopj.svg" height="50" alt="7332 Logo"
+    <a class="navbar-brand" href="about.html#puddlejumpers"><img src="images/logopj.svg" height="50" alt="7332 Logo"
         loading="lazy" /></a>
     <!-- the sandwich (menu) button that appears when the navbarContent collapses -->
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent"
@@ -199,7 +199,7 @@
               Templeton Robotics Club. <br /><br />This team was registered in
               Sept. 2020.
             </p>
-            <a class="btn btn-primary btn-lg my-3" href="about.html#pjoffset">More Info</a>
+            <a class="btn btn-primary btn-lg my-3" href="about.html#puddlejumpers">More Info</a>
           </div>
         </div>
       </div>

--- a/robotics_camp.html
+++ b/robotics_camp.html
@@ -64,7 +64,7 @@
     <nav class="navbar navbar-expand-md navbar-dark sticky-top rainstorms-dark">
         <!-- our logos (which link to the home page and the puddle jumpers section of the about page, respectively) -->
         <a class="navbar-brand" href="/"><img src="images/logo.svg" height="50" alt="7190 Logo" loading="lazy" /></a>
-        <a class="navbar-brand" href="about.html#pjoffset"><img src="images/logopj.svg" height="50" alt="7332 Logo"
+        <a class="navbar-brand" href="about.html#puddlejumpers"><img src="images/logopj.svg" height="50" alt="7332 Logo"
                 loading="lazy" /></a>
         <!-- the sandwich (menu) button that appears when the navbarContent collapses -->
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent"

--- a/robots.html
+++ b/robots.html
@@ -45,7 +45,7 @@
         <nav class="navbar navbar-expand-md navbar-dark sticky-top rainstorms-dark">
             <!-- our logos (which link to the home page and the puddle jumpers section of the about page, respectively) -->
             <a class="navbar-brand" href="/"><img src="images/logo.svg" height="50" alt="7190 Logo" loading="lazy"></a>
-            <a class="navbar-brand" href="about.html#pjoffset"><img src="images/logopj.svg" height="50" alt="7332 Logo" loading="lazy"></a>
+            <a class="navbar-brand" href="about.html#puddlejumpers"><img src="images/logopj.svg" height="50" alt="7332 Logo" loading="lazy"></a>
             <!-- the sandwich (menu) button that appears when the navbarContent collapses -->
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/teams.html
+++ b/teams.html
@@ -45,7 +45,7 @@
       <nav class="navbar navbar-expand-md navbar-dark sticky-top rainstorms-dark">
         <!-- our logos (which link to the home page and the puddle jumpers section of the about page, respectively) -->
         <a class="navbar-brand" href="/"><img src="images/logo.svg" height="50" alt="7190 Logo" loading="lazy"></a>
-        <a class="navbar-brand" href="about.html#pjoffset"><img src="images/logopj.svg" height="50" alt="7332 Logo" loading="lazy"></a>
+        <a class="navbar-brand" href="about.html#puddlejumpers"><img src="images/logopj.svg" height="50" alt="7332 Logo" loading="lazy"></a>
         <!-- the sandwich (menu) button that appears when the navbarContent collapses -->
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
The id `pjoffset` was removed sometime, breaking the Puddle Jumpers link (https://templetonrobotics.ca/about.html#pjoffset) in the header. I've readded the section link with `#puddlejumpers` and `scroll-margin-top`.